### PR TITLE
Updated DiscNewsRepository Tests to Ensure Correct Parallel Read Limi…

### DIFF
--- a/src/main/kotlin/coroutines/dispatcher/DiscNewsRepository.kt
+++ b/src/main/kotlin/coroutines/dispatcher/DiscNewsRepository.kt
@@ -81,7 +81,7 @@ class DiscNewsRepositoryTests {
                 }
             }
         }
-        assert(time > 2000) { "Should take less than 2000, took $time" }
+        assert(time < 2000) { "Should take less than 2000, took $time" }
     }
 
     class OneSecDiscReader(private val response: List<String>) : DiscReader {


### PR DESCRIPTION
Changes:

Test Adjustment: Corrected the test condition for the test should not allow more than 200 parallel reads to ensure it verifies the correct behavior when the parallelism limit is exceeded.

Previously: assert(time > 2000) { "Should take less than 2000, took $time" }
Now: assert(time < 2000) { "Should take less than 2000, took $time" }