### PR TITLE
update java 20 to 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,5 +42,5 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 kotlin {
-    jvmToolchain(20)
+    jvmToolchain(21)
 }


### PR DESCRIPTION
Java 20 is no longer officially supported, and Java 21 is the most recent LTS. It is pretty likely that people will have 21 installed on their system and not 20.

This will save people some time doing a chore when they first check out the repo, so they can go right to solving the fun exercises :smile: 